### PR TITLE
refactor: seperate store distance(#4)

### DIFF
--- a/data/local/src/main/kotlin/local_mapper/FavoriteMapper.kt
+++ b/data/local/src/main/kotlin/local_mapper/FavoriteMapper.kt
@@ -7,10 +7,10 @@ import local_mapper.UserMapper.toUser
 
 internal object FavoriteMapper {
 
-    fun FavoriteEntity.toFavorite(distance: Double = Double.NaN) = Favorite(
+    fun FavoriteEntity.toFavorite() = Favorite(
         id = id.value,
         user = user.toUser(),
-        store = store.toStore(distance = distance)
+        store = store.toStore()
     )
 
     fun List<FavoriteEntity>.toFavorite() = map { it.toFavorite() }

--- a/data/local/src/main/kotlin/local_mapper/StoreMapper.kt
+++ b/data/local/src/main/kotlin/local_mapper/StoreMapper.kt
@@ -3,13 +3,30 @@ package local_mapper
 import Menu
 import Store
 import StoreDetail
+import StoreWithDistance
 import local_dao.MenuEntity
 import local_dao.StoreDetailEntity
 import local_dao.StoreEntity
 
 internal object StoreMapper {
+    fun StoreEntity.toStoreWithDistance(distance: Double): StoreWithDistance {
+        val store = Store(
+            id = id.value,
+            name = name,
+            address = address,
+            favoriteCount = favoriteCount,
+            latitude = latitude,
+            longitude = longitude,
+            category = category,
+            phone = phone,
+            city = city,
+            district = district,
+            imageUrl = imageUrl,
+        )
+        return StoreWithDistance(store = store, distance = distance)
+    }
 
-    fun StoreEntity.toStore(distance: Double) = Store(
+    fun StoreEntity.toStore() = Store(
         id = id.value,
         name = name,
         address = address,
@@ -21,7 +38,6 @@ internal object StoreMapper {
         city = city,
         district = district,
         imageUrl = imageUrl,
-        distance = distance
     )
 
     fun StoreDetailEntity.toDetail() = StoreDetail(

--- a/data/local/src/main/kotlin/local_repository/impl/StoreRepositoryImpl.kt
+++ b/data/local/src/main/kotlin/local_repository/impl/StoreRepositoryImpl.kt
@@ -2,18 +2,20 @@ package local_repository.impl
 
 import Store
 import StorePage
+import StoreWithDistance
 import local_dao.StoreEntity
 import local_mapper.StoreMapper.toStore
-import org.jetbrains.exposed.sql.*
-import org.jetbrains.exposed.sql.statements.UpdateStatement
-import query.StoreQuerySortType
-import repository.local.StoreRepository
+import local_mapper.StoreMapper.toStoreWithDistance
 import local_repository.util.DoubleExpression
 import local_repository.util.RepositoryUtil.calculateDistance
 import local_repository.util.RepositoryUtil.dbQuery
 import local_repository.util.SortUtil.toSortPair
 import local_table.FavoriteTable
 import local_table.StoreTable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.statements.UpdateStatement
+import query.StoreQuerySortType
+import repository.local.StoreRepository
 import java.util.*
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -24,7 +26,7 @@ internal class StoreRepositoryImpl : StoreRepository {
     override suspend fun create(store: Store): Store = dbQuery {
         StoreEntity.new {
             applyStore(store = store)
-        }.toStore(distance = Double.NaN)
+        }.toStore()
     }
 
     override suspend fun update(store: Store): Store = dbQuery {
@@ -34,7 +36,7 @@ internal class StoreRepositoryImpl : StoreRepository {
 
         entity
             .applyStore(store = store)
-            .toStore(distance = Double.NaN)
+            .toStore()
     }
 
     override suspend fun count(): Long = dbQuery {
@@ -60,7 +62,7 @@ internal class StoreRepositoryImpl : StoreRepository {
     override suspend fun findById(id: UUID): Store? = dbQuery {
         StoreEntity
             .findById(id = id)
-            ?.toStore(distance = Double.NaN)
+            ?.toStore()
     }
 
     override suspend fun findByNameAndAddress(
@@ -70,14 +72,14 @@ internal class StoreRepositoryImpl : StoreRepository {
         StoreEntity
             .find { (StoreTable.name eq name) and (StoreTable.address eq address) }
             .firstOrNull()
-            ?.toStore(distance = Double.NaN)
+            ?.toStore()
     }
 
     override suspend fun findStoreByIdWithDistance(
         id: UUID,
         latitude: Double,
         longitude: Double
-    ): Store? = dbQuery {
+    ): StoreWithDistance? = dbQuery {
         StoreEntity.findById(id = id)?.let { entity: StoreEntity ->
             val distance: Double = calculateDistance(
                 lat1 = latitude,
@@ -86,7 +88,7 @@ internal class StoreRepositoryImpl : StoreRepository {
                 lon2 = entity.longitude
             )
 
-            entity.toStore(distance = distance)
+            entity.toStoreWithDistance(distance = distance)
         }
     }
 
@@ -154,8 +156,8 @@ internal class StoreRepositoryImpl : StoreRepository {
         }
 
         // 결과 매핑
-        val rows = query.map { row: ResultRow ->
-            Store(
+        val rows: List<StoreWithDistance> = query.map { row: ResultRow ->
+            val store = Store(
                 id = row[StoreTable.id].value,
                 name = row[StoreTable.name],
                 address = row[StoreTable.address],
@@ -167,12 +169,13 @@ internal class StoreRepositoryImpl : StoreRepository {
                 city = row[StoreTable.city],
                 district = row[StoreTable.district],
                 imageUrl = row[StoreTable.imageUrl],
-                distance = row[distanceExpr]
             )
+            val distance: Double = row[distanceExpr]
+            StoreWithDistance(store = store, distance = distance)
         }
 
         val hasNext: Boolean = rows.size > size
-        val stores: List<Store> = if (hasNext) rows.dropLast(n = 1) else rows
+        val stores: List<StoreWithDistance> = if (hasNext) rows.dropLast(n = 1) else rows
         val hasPrev: Boolean = page > 1
 
         StorePage(

--- a/domain/src/main/kotlin/service/StoreService.kt
+++ b/domain/src/main/kotlin/service/StoreService.kt
@@ -1,9 +1,9 @@
 package service
 
 import Menu
-import Store
 import StoreDetail
 import StorePage
+import StoreWithDistance
 import query.StoreQueryCategory
 import query.StoreQueryDistance
 import query.StoreQuerySortType
@@ -24,7 +24,7 @@ interface StoreService {
         onlyFavorites: Boolean,
     ): StorePage
 
-    suspend fun getStoreById(storeId: UUID, latitude: Double, longitude: Double): Store
+    suspend fun getStoreById(storeId: UUID, latitude: Double, longitude: Double): StoreWithDistance
 
     suspend fun getStoreDetail(storeId: UUID): StoreDetail
 

--- a/model/src/main/kotlin/Store.kt
+++ b/model/src/main/kotlin/Store.kt
@@ -1,4 +1,4 @@
-import java.util.UUID
+import java.util.*
 
 data class Store(
     val id: UUID,
@@ -12,5 +12,4 @@ data class Store(
     val city: String,
     val district: String?,
     val imageUrl: String?,
-    val distance: Double
 )

--- a/model/src/main/kotlin/StorePage.kt
+++ b/model/src/main/kotlin/StorePage.kt
@@ -1,5 +1,5 @@
 data class StorePage(
-    val stores: List<Store>,
+    val stores: List<StoreWithDistance>,
     val hasNext: Boolean,
     val hasPrev: Boolean
 )

--- a/model/src/main/kotlin/StoreWithDistance.kt
+++ b/model/src/main/kotlin/StoreWithDistance.kt
@@ -1,0 +1,4 @@
+data class StoreWithDistance(
+    val store: Store,
+    val distance: Double,
+)

--- a/router/src/main/kotlin/route/StoreRoute.kt
+++ b/router/src/main/kotlin/route/StoreRoute.kt
@@ -1,9 +1,9 @@
 package route
 
 import Menu
-import Store
 import StoreDetail
 import StorePage
+import StoreWithDistance
 import io.ktor.http.*
 import io.ktor.server.plugins.di.*
 import io.ktor.server.response.*
@@ -148,7 +148,7 @@ private fun Route.registerGetStore(storeService: StoreService) = get(path = "") 
     val storeId: UUID = call.getId(paramName = STORE_ID)
     val lat: Double = call.getDoubleParam(name = LATITUDE, defaultValue = DEFAULT_LATITUDE)
     val lng: Double = call.getDoubleParam(name = LONGITUDE, defaultValue = DEFAULT_LONGITUDE)
-    val store: Store = storeService.getStoreById(storeId = storeId, latitude = lat, longitude = lng)
+    val store: StoreWithDistance = storeService.getStoreById(storeId = storeId, latitude = lat, longitude = lng)
     call.respond(status = HttpStatusCode.OK, message = store.toStoreDTO())
 }
 

--- a/router/src/main/kotlin/route_mapper/StoreMapper.kt
+++ b/router/src/main/kotlin/route_mapper/StoreMapper.kt
@@ -1,9 +1,9 @@
 package route_mapper
 
 import Menu
-import Store
 import StoreDetail
 import StorePage
+import StoreWithDistance
 import route_dto.MenuDTO
 import route_dto.StoreDTO
 import route_dto.StoreDetailDTO
@@ -13,18 +13,18 @@ import kotlin.uuid.toKotlinUuid
 
 @OptIn(ExperimentalUuidApi::class)
 internal object StoreMapper {
-    fun Store.toStoreDTO() = StoreDTO(
-        id = id.toKotlinUuid(),
-        name = name,
-        address = address,
-        favoriteCount = favoriteCount,
-        latitude = latitude,
-        longitude = longitude,
-        category = category,
-        phone = phone,
-        city = city,
-        district = district,
-        imageUrl = imageUrl,
+    fun StoreWithDistance.toStoreDTO() = StoreDTO(
+        id = store.id.toKotlinUuid(),
+        name = store.name,
+        address = store.address,
+        favoriteCount = store.favoriteCount,
+        latitude = store.latitude,
+        longitude = store.longitude,
+        category = store.category,
+        phone = store.phone,
+        city = store.city,
+        district = store.district,
+        imageUrl = store.imageUrl,
         distance = distance,
     )
 

--- a/service/src/main/kotlin/repository/local/StoreRepository.kt
+++ b/service/src/main/kotlin/repository/local/StoreRepository.kt
@@ -2,6 +2,7 @@ package repository.local
 
 import Store
 import StorePage
+import StoreWithDistance
 import query.StoreQuerySortType
 import java.util.*
 
@@ -13,7 +14,7 @@ interface StoreRepository {
     suspend fun decrementFavoriteCount(id: UUID)
     suspend fun findById(id: UUID): Store?
     suspend fun findByNameAndAddress(name: String, address: String): Store?
-    suspend fun findStoreByIdWithDistance(id: UUID, latitude: Double, longitude: Double): Store?
+    suspend fun findStoreByIdWithDistance(id: UUID, latitude: Double, longitude: Double): StoreWithDistance?
     suspend fun findStores(
         userId: UUID,
         latitude: Double,

--- a/service/src/main/kotlin/service/impl/StoreServiceImpl.kt
+++ b/service/src/main/kotlin/service/impl/StoreServiceImpl.kt
@@ -1,9 +1,9 @@
 package service.impl
 
 import Menu
-import Store
 import StoreDetail
 import StorePage
+import StoreWithDistance
 import query.StoreQueryCategory
 import query.StoreQueryDistance
 import query.StoreQuerySortType
@@ -47,7 +47,7 @@ internal class StoreServiceImpl(
         storeId: UUID,
         latitude: Double,
         longitude: Double
-    ): Store = storeRepository.findStoreByIdWithDistance(
+    ): StoreWithDistance = storeRepository.findStoreByIdWithDistance(
         id = storeId,
         latitude = latitude,
         longitude = longitude

--- a/service/src/main/kotlin/service/mapper/StoreMapper.kt
+++ b/service/src/main/kotlin/service/mapper/StoreMapper.kt
@@ -21,7 +21,6 @@ internal object StoreMapper {
         city = city,
         district = district,
         imageUrl = imageUrl,
-        distance = Double.NaN
     )
 
     fun RemoteStore.toStoreDetail(storeId: UUID) = StoreDetail(


### PR DESCRIPTION
# 🔧 Store 도메인 모델에서 distance 분리

## 📋 변경 사항

`Store` 엔티티에서 `distance` 필드를 제거하고, `StoreWithDistance` 클래스를 도입하여 거리 정보를 분리했습니다.

## 🐛 문제점

- `distance`는 `Store` 엔티티의 고유 속성이 아니라 사용자 위치에 따라 달라지는 계산값
- 도메인 모델에 순수하지 않은 속성이 포함되어 의미론적 명확성이 떨어짐
- 거리 정보가 없는 경우 `Double.NaN`을 사용하여 타입 안정성이 저해됨
- 동일한 `Store` 인스턴스가 사용자 위치에 따라 다른 `distance` 값을 가질 수 있어 데이터 일관성 문제

## ✅ 해결 방법

컴포지션 패턴을 사용하여 `Store`와 `distance`를 분리하고, `StoreWithDistance` 데이터 클래스를 도입했습니다.

```kotlin
data class StoreWithDistance(
    val store: Store,
    val distance: Double
)
```

## 📝 주요 변경

- `Store`에서 `distance` 필드 제거
- `StoreWithDistance` 추가 (Store + distance 컴포지션)
- `StorePage.stores`를 `List<Store>`에서 `List<StoreWithDistance>`로 변경
- Repository, Service, Router 레이어 순차적 리팩토링
- 매퍼 로직에서 `StoreWithDistance` 처리 추가

## 📌 참고

- API 응답 구조는 변경 없음 (내부 구현만 개선)
- 거리 정보가 필요한 API는 `StoreWithDistance`를 반환하고, 필요 없는 경우 `Store`를 반환하여 책임이 명확히 구분됨
