### PR TITLE
feat: map search with geohash(#1)

### DIFF
--- a/data/local/build.gradle.kts
+++ b/data/local/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(libs.mariadb.java.client)
     implementation(libs.kotlinx.datetime)
     implementation(libs.hikari.cp)
+    implementation(libs.geohash)
     testImplementation(libs.kotlin.test.junit)
 }
 

--- a/data/local/src/main/kotlin/local_dao/StoreEntity.kt
+++ b/data/local/src/main/kotlin/local_dao/StoreEntity.kt
@@ -23,4 +23,5 @@ internal class StoreEntity(id: EntityID<UUID>) : UUIDEntity(id = id) {
     var city: String by StoreTable.city
     var district: String? by StoreTable.district
     var imageUrl: String? by StoreTable.imageUrl
+    var geoHash: String by StoreTable.geohash
 }

--- a/data/local/src/main/kotlin/local_repository/impl/StoreRepositoryImpl.kt
+++ b/data/local/src/main/kotlin/local_repository/impl/StoreRepositoryImpl.kt
@@ -7,6 +7,7 @@ import local_dao.StoreEntity
 import local_mapper.StoreMapper.toStore
 import local_mapper.StoreMapper.toStoreWithDistance
 import local_repository.util.DoubleExpression
+import local_repository.util.LocationUtil
 import local_repository.util.RepositoryUtil.calculateDistance
 import local_repository.util.RepositoryUtil.dbQuery
 import local_repository.util.SortUtil.toSortPair
@@ -107,7 +108,14 @@ internal class StoreRepositoryImpl : StoreRepository {
         val offset: Long = (page - 1) * size.toLong()
         val limit: Int = size + 1
 
-        // 거리 계산
+        // Geohash 기반 필터링
+        val geohashPrefixes = LocationUtil.encodeWithNeighbors(
+            distanceKm = distanceRange ?: Double.MAX_VALUE,
+            latitude = latitude,
+            longitude = longitude,
+        )
+
+        // 거리 계산 (정확한 거리 계산 및 정렬용)
         val distanceSQL =
             "(6371 * acos(cos(radians($latitude)) * cos(radians(${StoreTable.latitude.name})) * " +
                     "cos(radians(${StoreTable.longitude.name}) - radians($longitude)) + " +
@@ -144,6 +152,14 @@ internal class StoreRepositoryImpl : StoreRepository {
         )
 
         val query: Query = baseTable.select(columns = columns).apply {
+            // Geohash prefix 조건 (9개 셀 중 하나라도 매칭)
+            andWhere {
+                // prefixes가 비어있지 않을 때만 조건 생성
+                geohashPrefixes
+                    .map { (StoreTable.geohash like "$it%") as Op<Boolean> }
+                    .reduce { acc, op -> acc or op }
+            }
+
             if (!category.isNullOrBlank()) andWhere { StoreTable.category eq category }
             if (!keyword.isNullOrBlank()) andWhere { StoreTable.name like "%$keyword%" }
             if (onlyFavorites) andWhere { FavoriteTable.userId eq userId }
@@ -196,6 +212,7 @@ internal class StoreRepositoryImpl : StoreRepository {
         city = store.city
         district = store.district
         imageUrl = store.imageUrl
+        geoHash = LocationUtil.encodeForStorage(latitude = latitude, longitude = longitude)
         updatedAt = Clock.System.now()
         return this
     }

--- a/data/local/src/main/kotlin/local_repository/util/LocationUtil.kt
+++ b/data/local/src/main/kotlin/local_repository/util/LocationUtil.kt
@@ -1,0 +1,53 @@
+package local_repository.util
+
+import ch.hsr.geohash.GeoHash
+
+/**
+ * 위치 기반 검색을 위한 Geohash 인코딩 유틸리티입니다.
+ */
+internal object LocationUtil {
+
+    // 저장 시 사용하는 기본 정밀도 (약 150m x 150m 오차 범위)
+    private const val STORAGE_PRECISION = 7
+
+    /**
+     * 중심 좌표와 8방향 인접 셀의 Geohash를 반환합니다.
+     *
+     * @param distanceKm 검색 반경 (단위: km)
+     * @param latitude 중심 위도
+     * @param longitude 중심 경도
+     * @return 중심 셀과 8개 인접 셀의 Geohash 문자열 리스트 (총 9개)
+     */
+    fun encodeWithNeighbors(distanceKm: Double, latitude: Double, longitude: Double): List<String> {
+        val precision: Int = getPrecisionFromDistance(distanceKm = distanceKm)
+        val centerGeohash: GeoHash = GeoHash.withCharacterPrecision(latitude, longitude, precision)
+
+        return buildList {
+            add(element = centerGeohash.toBase32())
+            centerGeohash.adjacent.forEach { adjacentGeohash: GeoHash ->
+                add(element = adjacentGeohash.toBase32())
+            }
+        }
+    }
+
+    /**
+     * 저장용 Geohash 생성 (최대 정밀도)
+     */
+    fun encodeForStorage(latitude: Double, longitude: Double): String {
+        return GeoHash.geoHashStringWithCharacterPrecision(latitude, longitude, STORAGE_PRECISION)
+    }
+
+    /**
+     * 거리(km)를 기반으로 Geohash 정밀도(문자 길이)를 결정합니다.
+     * Geohash 셀의 크기는 위도에 따라 다르지만, 일반적으로 다음 기준을 따릅니다.
+     */
+    private fun getPrecisionFromDistance(distanceKm: Double): Int = when {
+        distanceKm <= 0.005 -> 8    // ~19m
+        distanceKm <= 0.15 -> 7     // ~152m
+        distanceKm <= 1.2 -> 6      // ~1.2km
+        distanceKm <= 4.9 -> 5      // ~4.9km
+        distanceKm <= 39.7 -> 4     // ~39.7km
+        distanceKm <= 156.0 -> 3    // ~156km
+        else -> 2                   // ~1250km
+    }
+}

--- a/data/local/src/main/kotlin/local_table/BannerTable.kt
+++ b/data/local/src/main/kotlin/local_table/BannerTable.kt
@@ -1,9 +1,9 @@
 package local_table
 
+import local_util.DatabaseUtil.uuidPrimaryKey
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.sql.Column
-import local_util.DatabaseUtil.uuidPrimaryKey
 import java.util.*
 
 private const val BANNER_TABLE = "banner"
@@ -12,6 +12,7 @@ private const val IMAGE_URL = "imageUrl"
 
 internal object BannerTable : IdTable<UUID>(name = BANNER_TABLE) {
     override val id: Column<EntityID<UUID>> = uuidPrimaryKey()
+    override val primaryKey = PrimaryKey(columns = arrayOf(id))
     val url: Column<String> = varchar(name = URL, length = 255)
     val imageUrl: Column<String> = varchar(name = IMAGE_URL, length = 255)
 }

--- a/data/local/src/main/kotlin/local_table/FavoriteTable.kt
+++ b/data/local/src/main/kotlin/local_table/FavoriteTable.kt
@@ -1,10 +1,10 @@
 package local_table
 
+import local_util.DatabaseUtil.uuidPrimaryKey
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.ReferenceOption
-import local_util.DatabaseUtil.uuidPrimaryKey
 import java.util.*
 
 private const val FAVORITE_TABLE = "favorite"
@@ -14,7 +14,7 @@ private const val UNIQUE_NAME = "unique_user_store"
 
 internal object FavoriteTable : IdTable<UUID>(name = FAVORITE_TABLE) {
     override val id: Column<EntityID<UUID>> = uuidPrimaryKey()
-
+    override val primaryKey = PrimaryKey(columns = arrayOf(id))
     val storeId: Column<EntityID<UUID>> = reference(
         name = STORE_ID,
         foreign = StoreTable,

--- a/data/local/src/main/kotlin/local_table/MenuTable.kt
+++ b/data/local/src/main/kotlin/local_table/MenuTable.kt
@@ -19,6 +19,7 @@ private const val UPDATED_AT = "updatedAt"
 @OptIn(ExperimentalTime::class)
 internal object MenuTable : IdTable<UUID>(name = MENU_TABLE) {
     override val id: Column<EntityID<UUID>> = uuidPrimaryKey()
+    override val primaryKey = PrimaryKey(columns = arrayOf(id))
     val storeId: Column<EntityID<UUID>> = reference(name = STORE_ID, foreign = StoreTable)
     val name: Column<String> = varchar(name = NAME, length = 255)
     val price: Column<String> = varchar(name = PRICE, length = 255)

--- a/data/local/src/main/kotlin/local_table/StoreDetailTable.kt
+++ b/data/local/src/main/kotlin/local_table/StoreDetailTable.kt
@@ -19,6 +19,7 @@ private const val ALLOWS_GROUP = "allowsGroup"
 
 internal object StoreDetailTable : IdTable<UUID>(name = STORE_DETAIL_TABLE) {
     override val id: Column<EntityID<UUID>> = reference(name = STORE_ID, foreign = StoreTable)
+    override val primaryKey = PrimaryKey(columns = arrayOf(id))
     val hasParking: Column<Boolean> = bool(name = HAS_PARKING).default(defaultValue = false)
     val hasTakeout: Column<Boolean> = bool(name = HAS_TAKEOUT).default(defaultValue = false)
     val hasDelivery: Column<Boolean> = bool(name = HAS_DELIVERY).default(defaultValue = false)

--- a/data/local/src/main/kotlin/local_table/StoreTable.kt
+++ b/data/local/src/main/kotlin/local_table/StoreTable.kt
@@ -22,10 +22,13 @@ private const val PHONE = "phone"
 private const val CITY = "city"
 private const val DISTRICT = "district"
 private const val IMAGE_URL = "imageUrl"
+private const val GEOHASH = "geohash"
+private const val UNIQUE_NAME = "idx_$GEOHASH"
 
 @OptIn(ExperimentalTime::class)
 internal object StoreTable : IdTable<UUID>(name = STORE_TABLE) {
     override val id: Column<EntityID<UUID>> = uuidPrimaryKey()
+    override val primaryKey = PrimaryKey(columns = arrayOf(id))
     val name: Column<String> = varchar(name = NAME, length = 255)
     val address: Column<String> = varchar(name = ADDRESS, length = 255)
     val favoriteCount: Column<Int> = integer(name = FAVORITE_COUNT).default(defaultValue = 0)
@@ -37,4 +40,15 @@ internal object StoreTable : IdTable<UUID>(name = STORE_TABLE) {
     val city: Column<String> = varchar(name = CITY, length = 255)
     val district: Column<String?> = varchar(name = DISTRICT, length = 255).nullable()
     val imageUrl: Column<String?> = varchar(name = IMAGE_URL, length = 255).nullable()
+    val geohash: Column<String> = varchar(name = GEOHASH, length = 20)
+
+    init {
+        index(
+            customIndexName = UNIQUE_NAME,
+            isUnique = false,
+            columns = arrayOf(geohash),
+            functions = null,
+            filterCondition = null
+        )
+    }
 }

--- a/data/local/src/main/kotlin/local_table/SyncTimeTable.kt
+++ b/data/local/src/main/kotlin/local_table/SyncTimeTable.kt
@@ -16,5 +16,6 @@ private const val TIME = "time"
 @OptIn(ExperimentalTime::class)
 internal object SyncTimeTable : IdTable<UUID>(SYNC_TIME_TABLE) {
     override val id: Column<EntityID<UUID>> = uuidPrimaryKey()
+    override val primaryKey = PrimaryKey(columns = arrayOf(id))
     val time: Column<Instant> = timestamp(TIME).clientDefault { Clock.System.now() }
 }

--- a/data/local/src/main/kotlin/local_table/UserTable.kt
+++ b/data/local/src/main/kotlin/local_table/UserTable.kt
@@ -17,6 +17,7 @@ private const val ADDRESS = "address"
 @OptIn(ExperimentalTime::class)
 internal object UserTable : IdTable<UUID>(name = USER_TABLE) {
     override val id: Column<EntityID<UUID>> = uuidPrimaryKey()
+    override val primaryKey = PrimaryKey(columns = arrayOf(id))
     val createdAt: Column<Instant> = timestamp(name = CREATED_AT).clientDefault { Clock.System.now() }
     val address: Column<String> = varchar(name = ADDRESS, length = 255)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ jsoup = "1.21.2"
 poi = "5.5.1"
 mariadb = "3.5.6"
 hikari = "7.0.2"
+geohash = "1.4.0"
 
 [libraries]
 # Kotlin
@@ -51,6 +52,9 @@ poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi" }
 
 # hikari
 hikari-cp = { group = "com.zaxxer", name = "HikariCP", version.ref = "hikari" }
+
+# geohash
+geohash = { group = "ch.hsr", name = "geohash", version.ref = "geohash" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
# 🗺️ 지도 기반 가게 검색 개선 (Geohash 적용)

### 📌 기존

- 지도 기반 매장 검색 시 모든 매장에 대해 Haversine 공식을 적용하여 거리를 계산
- 검색 반경 내 매장을 찾기 위해 전체 테이블 스캔 발생
- 매장 수가 증가할수록 검색 성능 저하

### ❗ 문제

- 전체 매장에 대해 삼각함수 연산(cos, sin, acos)을 수행하여 DB 부하 증가
- 인덱스를 활용하지 못해 검색 반경 필터링에 O(N) 시간복잡도 소요
- 대량의 매장 데이터 처리 시 응답 속도 지연

### 🎯 목적

- Geohash 기반 공간 인덱싱을 도입하여 검색 성능 최적화
- DB 쿼리 단계에서 후보 매장을 빠르게 필터링
- 정확한 거리 계산은 필터링된 후보군에만 적용

### 🛠️ 개선 방향

1. **📦 Geohash 라이브러리 도입**
   - `ch.hsr:geohash:1.4.0` 의존성 추가

2. **🔧 Geohash 유틸리티 구현** (`LocationUtil.kt`)
   - 검색 반경에 따른 동적 정밀도 결정 (19m ~ 1250km)
   - 중심 좌표 + 8방향 인접 셀 Geohash 반환 (총 9개 셀)

3. **🗄️ StoreTable 스키마 변경**
   - `geohash` 컬럼 추가 (VARCHAR 20)
   - `idx_geohash` 인덱스 생성

4. **⚡ 검색 쿼리 최적화**
   - Geohash prefix 매칭으로 1차 필터링 (인덱스 활용)
   - 필터링된 결과에만 Haversine 거리 계산 적용

5. **🔑 테이블 PK 명시적 정의**
   - 모든 테이블에 `override val primaryKey` 추가

### ✅ 결과

| 항목 | 기존 | 개선 |
|------|------|------|
| 필터링 방식 | 🔴 전체 스캔 | 🟢 Geohash 인덱스 |
| 거리 계산 대상 | 🔴 전체 매장 | 🟢 인접 9개 셀 내 매장만 |
| 시간복잡도 | 🔴 O(N) | 🟢 O(log N) + O(M) |